### PR TITLE
Add binary dump and load functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ BloomFilter is a ruby library that implements an in-memory [Bloom Filter](http:/
     #insert
     #include?
     #bits
+    #binary
 
 ```
 
@@ -45,7 +46,12 @@ BloomFilter is a ruby library that implements an in-memory [Bloom Filter](http:/
   filter.dump "/tmp/random.bloom"
   filter = BloomFilter.load "/tmp/random.bloom"
 
-  bits = filter.bits #=> "10010100100111..."
+  bits   = filter.bits   #=> "10010100100111..."
+  binary = filter.binary #=> "\x83Ö\xAC\xEA\u00..."
+
+  filter2 = BloomFilter.new bits: 100_000_0, hashes: 4
+  filter2.binary = binary
+  filter2.include? "foo" #=> true
 ```
 
 ## See Also

--- a/ext/bloom_filter.c
+++ b/ext/bloom_filter.c
@@ -165,6 +165,32 @@ VALUE bloom_bits(VALUE klass) {
     return bitmap;
 }
 
+VALUE bloom_binary(VALUE klass) {
+    BloomFilter *filter = bloom_handle(klass);
+
+    VALUE bitmap;
+    char *buffer;
+
+    int nbytes = (filter->table_size + 7) / 8;
+    buffer = (char *)malloc(nbytes);
+
+    if (!buffer)
+        rb_raise(rb_eNoMemError, "out of memory dumping BloomFilter");
+
+    bloom_filter_read(filter, buffer);
+
+    bitmap = rb_str_new(buffer, nbytes);
+    free(buffer);
+    return bitmap;
+}
+
+VALUE bloom_binary_set(VALUE klass, VALUE buffer) {
+    BloomFilter *filter = bloom_handle(klass);
+    char* ptr = (char *) RSTRING_PTR(buffer);
+    bloom_filter_load(filter, ptr);
+    return Qtrue;
+}
+
 VALUE bloom_load(VALUE klass, VALUE file) {
     int fd;
     void *buffer;
@@ -211,6 +237,8 @@ void Init_bloom_filter() {
     rb_define_method(cBloom, "initialize", RUBY_METHOD_FUNC(bloom_initialize),  -1);
     rb_define_method(cBloom, "dump",       RUBY_METHOD_FUNC(bloom_dump),         1);
     rb_define_method(cBloom, "bits",       RUBY_METHOD_FUNC(bloom_bits),         0);
+    rb_define_method(cBloom, "binary",     RUBY_METHOD_FUNC(bloom_binary),       0);
+    rb_define_method(cBloom, "binary=",    RUBY_METHOD_FUNC(bloom_binary_set),   1);
     rb_define_method(cBloom, "insert",     RUBY_METHOD_FUNC(bloom_insert),       1);
     rb_define_method(cBloom, "include?",   RUBY_METHOD_FUNC(bloom_include),      1);
 

--- a/test/test_io.rb
+++ b/test/test_io.rb
@@ -12,4 +12,16 @@ describe 'BloomFilter load & dump' do
     assert filter.include?("foo")
     assert !filter.include?("bar")
   end
+
+  it 'should accept assigning the bits directly' do
+    assert filter = BloomFilter.new(bits: 80)
+    assert filter.insert("foo")
+    puts filter.binary.inspect
+    assert filter2 = BloomFilter.new(bits: 80)
+    assert filter2.binary = filter.binary
+    puts
+    puts filter2.binary.inspect
+    assert filter2.include?("foo")
+    assert !filter2.include?("bar")
+  end
 end


### PR DESCRIPTION
We needed the ability to load a filter bitmap in memory, instead of directly from file. We've added the `binary` attribute which allows one to get and set a bit string containing the filter data.

Example use case:

``` ruby
filter = BloomFilter.new bits: 100_000_0, hashes: 4

filter.insert "foo"
binary = filter.binary #=> "\x83Ö\xAC\xEA\u00..."

filter2 = BloomFilter.new bits: 100_000_0, hashes: 4
filter2.binary = binary
filter2.include? "foo" #=> true
filter2.include? "bar" #=> false
```
